### PR TITLE
Fix styles not being injected due to location including full url including arguments

### DIFF
--- a/stylish.safariextension/assets/script.js
+++ b/stylish.safariextension/assets/script.js
@@ -105,7 +105,9 @@ function pong(event) {
 		metaid = getMeta('stylish-id-url')?getMeta('stylish-id-url').replace(/^https?:\/\/userstyles.org\/styles\//,''):false;
 	switch(n) {
 		case 'injectStyle':
-			if (m.location == dl.href) injectStyle(m.css, m.id);
+			var filteredLocation = m.location.split('?')[0]
+			var filteredHref = dl.href.split('?')[0]
+			if (filteredLocation == filteredHref) injectStyle(m.css, m.id);
 		break;
 		case 'removeStyle':
 			removeStyle(m.id);


### PR DESCRIPTION
This fixes https://github.com/350d/stylish/issues/34

I added some console logging to the `script.js` file to see what was going on.

The issue was `m.location` appears to include the url arguments _on occasion_ which causes a mismatch between `m.location` and `dl.href` since `dl.href` was not including these arguments.

I'm not sure if `dl.href` would ever also include the url arguments but just incase I've also filtered that as well.

I guess if for some reason there would be the want or need to match url arguments in this method instead of just the base url. Then obviously this would cause issues with that. 

<img width="897" alt="screen shot 2017-10-19 at 5 56 22 pm" src="https://user-images.githubusercontent.com/439440/31796871-6e3a8ca6-b4f9-11e7-9288-3439e76f7f64.png">